### PR TITLE
Adding POST and GET endpoints for Orders

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ const ajv = new Ajv();
 app.post("/orders", async (req, res) => {
   let order = req.body;
   // order details
-  let responseStatus = order.productQuantity ? 200 : 400;
+  let responseStatus = order.productQuantity
+    ? 200
+    : 400 && order.ShippingAddress
+    ? 200
+    : 400;
+
   if (responseStatus === 200) {
     try {
       // addOrder function to handle order creation in the database
@@ -48,8 +53,8 @@ app.post("/orders", async (req, res) => {
   res.status(responseStatus).send();
 });
 
-app.get("/orders:orderId", async (req, res) => {
-  // get all orders from the database
+app.get("/orders/:orderId", async (req, res) => {
+  // get the order from the database
   const orderId = req.params.orderId;
   let order = await getOrder({ redisClient, orderId });
   if (order === null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "ajv": "^8.12.0",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -84,6 +85,21 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anymatch": {
@@ -405,6 +421,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -648,6 +669,11 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -872,6 +898,14 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -930,6 +964,14 @@
         "@redis/json": "1.0.6",
         "@redis/search": "1.1.6",
         "@redis/time-series": "1.0.5"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1127,6 +1169,14 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "ajv": "^8.12.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,8 @@
+{
+    "type": "object",
+    "properties": {
+      "ShipmentAddress": { "type": "string" }
+    },
+    "required": ["ShipmentAddress"]
+  }
+  

--- a/services/orderservice.js
+++ b/services/orderservice.js
@@ -1,40 +1,21 @@
-const redis = require("redis");
+const addOrder = async ({ redisClient, order }) => {
+  customerKey = 1;
+  const existingCustomer = customerKey;
+  //const customerKey = `customer:${order.customerId}`;
+  // const existingCustomer = await redisClient.json.get(customerKey);
+  if (existingCustomer !== null) {
+    const orderKey = `order:${order.customerId}-${Date.now()}`;
+    order.orderId = orderKey;
 
-// Create a Redis client
-const client = redis.createClient();
-
-// Connect to Redis
-client.on("connect", () => {
-  console.log("Connected to Redis");
-});
-
-// Handle GET request
-function getOrder(orderId) {
-  return new Promise((resolve, reject) => {
-    client.get(orderId, (err, result) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-}
-
-// Handle POST request
-function createOrder(orderId, orderData) {
-  return new Promise((resolve, reject) => {
-    client.set(orderId, orderData, (err, result) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-}
-
-module.exports = {
-  getOrder,
-  createOrder,
+    // Create the order data in Redis
+    await redisClient.json.set(orderKey, "$", order);
+  } else {
+    throw new Error(`Customer ${customerKey} does not exist`);
+  }
 };
+const getOrder = async ({ redisClient, orderId }) => {
+  const resultObject = await redisClient.json.get(`order:${orderId}`);
+  return resultObject;
+};
+//module.exports = { addOrder, getOrder };
+module.exports = { addOrder, getOrder };

--- a/services/orderservice.js
+++ b/services/orderservice.js
@@ -1,0 +1,40 @@
+const redis = require("redis");
+
+// Create a Redis client
+const client = redis.createClient();
+
+// Connect to Redis
+client.on("connect", () => {
+  console.log("Connected to Redis");
+});
+
+// Handle GET request
+function getOrder(orderId) {
+  return new Promise((resolve, reject) => {
+    client.get(orderId, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+// Handle POST request
+function createOrder(orderId, orderData) {
+  return new Promise((resolve, reject) => {
+    client.set(orderId, orderData, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+module.exports = {
+  getOrder,
+  createOrder,
+};

--- a/services/orderservice.js
+++ b/services/orderservice.js
@@ -1,8 +1,11 @@
 const addOrder = async ({ redisClient, order }) => {
-  customerKey = 1;
-  const existingCustomer = customerKey;
-  //const customerKey = `customer:${order.customerId}`;
-  // const existingCustomer = await redisClient.json.get(customerKey);
+  //Temporary hardcoding of customer ID
+  order.customerId = 3852656789;
+  //use the const to pull the customer ID from the order object
+
+  const existingCustomer = order.customerId;
+  const customerKey = `customer:${order.customerId}`;
+  //const existingCustomer = await redisClient.json.get(customerKey);
   if (existingCustomer !== null) {
     const orderKey = `order:${order.customerId}-${Date.now()}`;
     order.orderId = orderKey;


### PR DESCRIPTION
This pull request introduces two new endpoints for handling Orders in our application:

1. `POST /orders`: This endpoint allows clients to create a new order. The client only needs to provide the ProductQuantity, and Shipping Address; all other data will be auto-generated or retrieved from other services.

2. `GET /orders/:orderId`: This endpoint allows clients to retrieve an existing order by its ID. If the order does not exist, a 404 status code is returned.

These changes will allow our application to handle the creation and retrieval of orders, which is a crucial part of our business logic.